### PR TITLE
Add KANN, a deep learning library in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ as C/C++, as this is not an obstacle to most users.)
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 |  [micropather](http://www.grinninglizard.com/MicroPather/)            | zlib                 | C++ |  2  | pathfinding with A\*
 |  [Genann](https://github.com/codeplea/genann)                         | zlib                 |C/C++|  2  | simple neural networks (ANN)
+|  _[KANN](https://github.com/attractivechaos/kann)_                    | MIT                  |  C  | 2-4 | automatic differentiation (2 files) and deep learning (4 files)
 
 # argv
 | library                                                               | license              | API |files| description

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ as C/C++, as this is not an obstacle to most users.)
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 |  [micropather](http://www.grinninglizard.com/MicroPather/)            | zlib                 | C++ |  2  | pathfinding with A\*
 |  [Genann](https://github.com/codeplea/genann)                         | zlib                 |C/C++|  2  | simple neural networks (ANN)
-|  _[KANN](https://github.com/attractivechaos/kann)_                    | MIT                  |  C  | 2-4 | automatic differentiation (2 files) and deep learning (4 files)
+|  _[KANN](https://github.com/attractivechaos/kann)_                    | MIT                  |C/C++| 2-4 | automatic differentiation (2 files) and deep learning (4 files)
 
 # argv
 | library                                                               | license              | API |files| description


### PR DESCRIPTION
[KANN](https://github.com/attractivechaos/kann) is like a CPU-only mini-[tensorflow](https://www.tensorflow.org), providing common components for deep learning. KANN implements automatic differentiation (autodiff; the foundation of general deep learning frameworks) in two files `kautodiff.{h,c}` and implements deep learning utilities in two additional files. So, if you need autodiff only, take two files; if you need deep learning, take all four files.

I am fully aware that the rule is "libraries should use at most two files", but I also notice "exceptions will be allowed for good reasons". In case of KANN, "good reasons" include 1) autodiff is logically separated from deep learning and is more general; 2) the autodiff part of KANN is qualified for a two-file library; 3) KANN is already the smallest of its kind with most other frameworks many times larger.

I hope you may consider KANN as an exception, but if you prefer to reject this PR, I also fully understand. Thanks in advance.