### PR TITLE
Add NanoJPEG

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [miniexr](https://github.com/aras-p/miniexr)                         | **public domain**    | C++ |  2  | OpenEXR writer, needs header file
 |   |  [tinyexr](https://github.com/syoyo/tinyexr)                          | BSD                  |C/C++|**1**| EXR image read/write, uses miniz internally  
 |   |  [lodepng](http://lodev.org/lodepng/)                                 | zlib                 |C/C++|  2  | PNG encoder/decoder
+|   |  [NanoJPEG](http://keyj.emphy.de/nanojpeg/)                           | MIT                  |C/C++|**1**| JPEG decoder
 |   |  [nanoSVG](https://github.com/memononen/nanosvg)                      | zlib                 |C/C++|**1**| 1-file SVG parser; 1-file SVG rasterizer
 |   |  [picopng.cpp](http://lodev.org/lodepng/picopng.cpp)                  | zlib                 | C++ |  2  | tiny PNG loader
 |   |  [jpeg-compressor](https://github.com/richgel999/jpeg-compressor)     | **public domain**    | C++ |  2  | 2-file jpeg compress, 2-file jpeg decompress

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [miniexr](https://github.com/aras-p/miniexr)                         | **public domain**    | C++ |  2  | OpenEXR writer, needs header file
 |   |  [tinyexr](https://github.com/syoyo/tinyexr)                          | BSD                  |C/C++|**1**| EXR image read/write, uses miniz internally  
 |   |  [lodepng](http://lodev.org/lodepng/)                                 | zlib                 |C/C++|  2  | PNG encoder/decoder
-|   |  [NanoJPEG](http://keyj.emphy.de/nanojpeg/)                           | MIT                  |C/C++|**1**| JPEG decoder
+| * |  [NanoJPEG](http://keyj.emphy.de/nanojpeg/)                           | MIT                  |C/C++|**1**| JPEG decoder
 |   |  [nanoSVG](https://github.com/memononen/nanosvg)                      | zlib                 |C/C++|**1**| 1-file SVG parser; 1-file SVG rasterizer
 |   |  [picopng.cpp](http://lodev.org/lodepng/picopng.cpp)                  | zlib                 | C++ |  2  | tiny PNG loader
 |   |  [jpeg-compressor](https://github.com/richgel999/jpeg-compressor)     | **public domain**    | C++ |  2  | 2-file jpeg compress, 2-file jpeg decompress


### PR DESCRIPTION
From the [webpage](http://keyj.emphy.de/nanojpeg/):
>... Here are the bullet points:
>* decodes baseline JPEG only, no progressive or lossless JPEG
>* supports 8-bit grayscale and YCbCr images, no 16 bit, CMYK or other color spaces
>* supports any power-of-two chroma subsampling ratio
>* supports restart markers
>* the four points above mean that it **should be able to decode all digital camera JPEG files** and many other JPEG files
>* below 900 lines of code (and that already includes over 200 lines of comments and empty lines!)
>* converts YCbCr to RGB
>* uses a bicubic chrominance upsampling filter (this is actually better than the mere bilinear filter of libjpeg!)
>* a little slower than libjpeg
>* memory requirements: ~512 KiB (static) + 1x the decoded image size for grayscale images or 2x the decoded image size for color images
>* very simple API
>* input: memory dumps of JPEG files
>* output: memory dumps of raw, uncompressed 8-bit grayscale or 24-bit RGB pixels
>* output format is compatible to the PGM/PPM file formats as well as OpenGL `GL_LUMINANCE8`/`GL_RGB8` texture formats
>* not fault-tolerant – any bitstream error will stop the decoder immediately and return an error to the application
>* 100% pure C code
>* no warnings with GCC 4.3 `-pedantic` and MSVC `/W3`
>* 32-bit integer arithmetic only
>* supposed to be endianness independent
>* 64-bit clean
>* **not** thread-safe
>* platform-independent
>* includes some provisions to build ultra-small Win32 executables
>* open source (free-beer, but maybe not really free-speech software)
>* single C file
>* <s>batteries</s> example program included

Despite what it says about "free-beer, but maybe not really free-speech software" the license is now MIT.