### PR TITLE
Adding single .h file for memory address editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ as C/C++, as this is not an obstacle to most users.)
 # files & filenames
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings 
+|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings
 |   |  [whereami](https://github.com/gpakosz/whereami)                      | **WTFPLv2**          |C/C++|  2  | get path/filename of executable or module
 |   |  [dirent](https://github.com/tronkko/dirent)                          | MIT                  |C/C++|**1**| dirent for windows: retrieve file & dir info
 |   |  [TinyDir](https://github.com/cxong/tinydir)                          | BSD                  |  C  |**1**| cross-platform directory reading (win/posix/mingw)

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ as C/C++, as this is not an obstacle to most users.)
 
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|   |  [easyMemoryAddressEditor](https://github.com/Kevin-Duarte/easyMemoryAddressEditor)| **public domain**                 |C++|  1  | Simple & easy memory address editor
+| * |  [easyMemoryAddressEditor](https://github.com/Kevin-Duarte/easyMemoryAddressEditor)| **public domain**|C++|**1**| Simple & easy memory address editor
 | * |  [cJSON](https://sourceforge.net/projects/cjson/)                     | MIT                  |C/C++|**1**| JSON parser
 | * |  [ajson](https://github.com/lordoffox/ajson)                          | Boost                | C++ |**1**| JSON serialize &
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ as C/C++, as this is not an obstacle to most users.)
 # files & filenames
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, 
+|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings 
 |   |  [whereami](https://github.com/gpakosz/whereami)                      | **WTFPLv2**          |C/C++|  2  | get path/filename of executable or module
 |   |  [dirent](https://github.com/tronkko/dirent)                          | MIT                  |C/C++|**1**| dirent for windows: retrieve file & dir info
 |   |  [TinyDir](https://github.com/cxong/tinydir)                          | BSD                  |  C  |**1**| cross-platform directory reading (win/posix/mingw)

--- a/README.md
+++ b/README.md
@@ -327,8 +327,6 @@ as C/C++, as this is not an obstacle to most users.)
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 | * |  [easyMemoryAddressEditor](https://github.com/Kevin-Duarte/easyMemoryAddressEditor)| **public domain**|C++|**1**| Simple & easy memory address editor
-| * |  [cJSON](https://sourceforge.net/projects/cjson/)                     | MIT                  |C/C++|**1**| JSON parser
-| * |  [ajson](https://github.com/lordoffox/ajson)                          | Boost                | C++ |**1**| JSON serialize &
 
 # strings
 |   | library                                                               | license              | API |files| description

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ as C/C++, as this is not an obstacle to most users.)
     - [string processing](#strings)
     - [scripting](#scripting)
     - [hashing](#hashing)
+  - memory maniputlation
+    - [memory editor](#memory)
   - mathematics
     - [vector math](#vectors)
     - [geometry math](#geometry-math)
@@ -157,7 +159,7 @@ as C/C++, as this is not an obstacle to most users.)
 # files & filenames
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings
+|   |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, 
 |   |  [whereami](https://github.com/gpakosz/whereami)                      | **WTFPLv2**          |C/C++|  2  | get path/filename of executable or module
 |   |  [dirent](https://github.com/tronkko/dirent)                          | MIT                  |C/C++|**1**| dirent for windows: retrieve file & dir info
 |   |  [TinyDir](https://github.com/cxong/tinydir)                          | BSD                  |  C  |**1**| cross-platform directory reading (win/posix/mingw)
@@ -319,6 +321,14 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [Picol](https://chiselapp.com/user/dbohdan/repository/picol/)        | BSD                  |C/C++|**1**| interpreter for a Tcl-like scripting language
 |   |  [s7](https://ccrma.stanford.edu/software/snd/snd/s7.html)            | BSD                  |C/C++|  2  | interpreter for a subset of Scheme (R5RS/R7RS)
 |   |  [Duktape](http://duktape.org/)                                       | MIT                  |  C  |  2  | embeddable Javascript engine
+
+# memory
+
+|   | library                                                               | license              | API |files| description
+|---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
+|   |  [easyMemoryAddressEditor](https://github.com/Kevin-Duarte/easyMemoryAddressEditor)| **public domain**                 |C++|  1  | Simple & easy memory address editor
+| * |  [cJSON](https://sourceforge.net/projects/cjson/)                     | MIT                  |C/C++|**1**| JSON parser
+| * |  [ajson](https://github.com/lordoffox/ajson)                          | Boost                | C++ |**1**| JSON serialize &
 
 # strings
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
The rules state that the .h file must work on all OS, but memory address editing is a VERY OS specific process. Therefore, I was only able to make a .h file for Windows, but if the library gains attention, I will look forward into creating a Linux OS library for memory address editing. 

Reason for this library: 
Memory address editing is very undocumented in many areas such as multi-level pointers and module base addresses.  Furthermore, there was no documentation on how to use memory address for 64 bit programs. Therefore, I sought out to create a 32-bit and 64-bit  compatible .h file that edits memory addresses.

Specifications:
one single .h file
64-bit and 32-bit compatible
Works on Windows OS
Public domain license
library is about 200 lines of code total