### PR TITLE
Recent update to levenshtein allows c/c++

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [tinyformat](https://github.com/c42f/tinyformat)                     | Boost                | C++ |**1**| typesafe printf
 |   |  [visit_struct](https://github.com/cbeck88/visit_struct)              | Boost                | C++ |  2  | struct-field reflection
 |   |  [stmr](https://github.com/wooorm/stmr.c)                             | MIT                  |  C  |  2  | extract English word stems
-|   |  [levenshtein](https://github.com/wooorm/levenshtein.c)               | MIT                  |  C  |  2  | compute edit distance between two strings
+|   |**[levenshtein](https://github.com/wooorm/levenshtein.c)**             | MIT                  |C/c++|  2  | compute edit distance between two strings
 |   |  [tinytime](https://github.com/RandyGaul/tinyheaders)                 | zlib                 |C/C++|**1**| quick-and-dirty time elapsed time
 | * |  [cpp-generators](https://github.com/c-smile/cpp-generators)          | BSD                  | C++ |**1**| generators in C++
 |   |  [PlusCallback](https://github.com/codeplea/pluscallback)             | zlib                 | C++ |**1**| function/method callbacks

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [tinyformat](https://github.com/c42f/tinyformat)                     | Boost                | C++ |**1**| typesafe printf
 |   |  [visit_struct](https://github.com/cbeck88/visit_struct)              | Boost                | C++ |  2  | struct-field reflection
 |   |  [stmr](https://github.com/wooorm/stmr.c)                             | MIT                  |  C  |  2  | extract English word stems
-|   |**[levenshtein](https://github.com/wooorm/levenshtein.c)**             | MIT                  |C/c++|  2  | compute edit distance between two strings
+|   |  [levenshtein](https://github.com/wooorm/levenshtein.c)               | MIT                  |C/C++|  2  | compute edit distance between two strings
 |   |  [tinytime](https://github.com/RandyGaul/tinyheaders)                 | zlib                 |C/C++|**1**| quick-and-dirty time elapsed time
 | * |  [cpp-generators](https://github.com/c-smile/cpp-generators)          | BSD                  | C++ |**1**| generators in C++
 |   |  [PlusCallback](https://github.com/codeplea/pluscallback)             | zlib                 | C++ |**1**| function/method callbacks


### PR DESCRIPTION
I added support to the levenshtein library to allow calling from c++. This points out that it is now compatible with both.

