### PR TITLE
add effolkronium random library

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [tinytime](https://github.com/RandyGaul/tinyheaders)                 | zlib                 |C/C++|**1**| quick-and-dirty time elapsed time
 |   |  [cpp-generators](https://github.com/c-smile/cpp-generators)          | BSD                  | C++ |**1**| generators in C++
 |   |  [PlusCallback](https://github.com/codeplea/pluscallback)             | zlib                 | C++ |**1**| function/method callbacks
+|   |  [random](https://github.com/effolkronium/random)                     | MIT                  | C++ |**1**| convenient API for random
 
 
 There are also these XML libraries, but if you're using XML, shame on you:                                             


### PR DESCRIPTION
Random for modern C++ with convenient API. Header-only.
https://github.com/effolkronium/random