### PR TITLE
Add Inja Template Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |**[strpool.h](https://github.com/mattiasgustavsson/libs)**             | **public domain**    |C/C++|**1**| string interning
 |   |  [dfa](http://bjoern.hoehrmann.de/utf-8/decoder/dfa/)                 | MIT                  |C/C++|  2  | fast utf8 decoder (need a header file)
 |   |**[gb_string.h](https://github.com/gingerBill/gb)**                    | **public domain**    |C/C++|**1**| dynamic strings
+|   |  [inja.hpp](https://github.com/pantor/inja)                           | MIT                  | C++ |**1**| template engine
 
 # tests
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
This PR adds the single-header [Inja](https://github.com/pantor/inja) template engine to the list.