### PR TITLE
Add sokol_gfx.h (3D API wrapper) and sokol_time.h (x-platform timing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |**[seamoptimizer](https://github.com/ands/seamoptimizer)**             | **public domain**    |C/C++|**1**| modify lightmap data to hide seams
 |   |  [tinygizmo](https://github.com/ddiakopoulos/tinygizmo)               | **public domain**    | C++ |  2  | gizmo objects for interactively editing 3d transformations
 |   |**[Vertex Cache Optimizer](https://github.com/Sigkill79/sts)**         | **public domain**    |C/C++|**1**| vertex cache optimization of meshes
+|   |  [sokol_gfx.h](https://github.com/floooh/sokol)                       | MIT                  |C/C++|**1**| cross-platform 3D API wrapper (GLES2+3/GL3/D3D11/Metal)
 
 # hardware
 |   | library                                                               | license              | API |files| description
@@ -398,6 +399,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [cpp-generators](https://github.com/c-smile/cpp-generators)          | BSD                  | C++ |**1**| generators in C++
 |   |  [PlusCallback](https://github.com/codeplea/pluscallback)             | zlib                 | C++ |**1**| function/method callbacks
 |   |  [random](https://github.com/effolkronium/random)                     | MIT                  | C++ |**1**| convenient API for random
+|   |  [sokol_time.h](https://github.com/floooh/sokol)                      | MIT                  |C/C++|**1**| cross-platform time measurement
 
 
 There are also these XML libraries, but if you're using XML, shame on you:                                             


### PR DESCRIPTION
This adds two of my dependency-free single-header-libs (both are in the same repo). They are written in C and callable from C and C++. Tested on clang, gcc and VS on Win7, Win10, OSX, Linux, iOS, Android, asm.js and WebAssembly:

- **sokol_gfx.h** is a simple, 'modern 3D API' wrapper around GLES2, GLES3, GL3.3, D3D11 and Metal
- **sokol_time.h** is a very simple set of functions for cross-platform time-measurement

I tried to follow the STB header design-philosophy (how configuration via macros works etc...).

PS: here are direct links to the headers:

- https://github.com/floooh/sokol/blob/master/sokol_gfx.h
- https://github.com/floooh/sokol/blob/master/sokol_time.h