### PR TITLE
Added Monocypher crypto library

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   | library                                                               | license              | API |files| description
 |---| --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 |   |  [TweetNaCl](http://tweetnacl.cr.yp.to/software.html)                 | **public domain**    |  C  |  2  | high-quality tiny cryptography library
+|   |  [Monocypher](https://monocypher.org)                                 | **public domain**    |  C  |  2  | high-quality small cryptography library
 
 # data structures
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
Note that it actually uses a dual licence, not just a 2-clause BSD. The other licence is closer to public domain (you don't even have to copy the licence and copyright notice).
