### PR TITLE
Add dmc_unrar

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [fastlz](https://code.google.com/archive/p/fastlz/source/default/source) | MIT              |C/C++|  2  | fast but larger LZ compression
 |   |  [pithy](https://github.com/johnezang/pithy)                          | BSD                  |C/C++|  2  | fast but larger LZ compression
 |   |  [microtar](https://github.com/rxi/microtar)                          | MIT                  |C/C++|  2  | lightweight tar library
+|   |  [dmc_unrar](https://github.com/DrMcCoy/dmc_unrar)                    | GPLv2+               |C/C++|**1**| RAR file decompression
 
 # crypto
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
In place of my issue #62, here's a pull request that adds dmc_unrar.

[dmc_unrar](https://github.com/DrMcCoy/dmc_unrar) is a dependency-free single-file library to unpack and decompress RAR archives, usable from both C and C++. The license is GPLv2+, though, because the unrar code is partially based on existing GPLv2+ and LGPLv2+ code.

It can unpack RAR 1.5, 2.0/2.6 (including audio/media compression), 2.9/3.6 (including PPMd, and all stock filters) and also RAR 5 now.