### PR TITLE
Add pocketmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [tinysound](https://github.com/RandyGaul/tinyheaders)                | zlib                 |C/C++|**1**| direct sound audio mixer & WAV loader
 |   |  [btac1c](https://github.com/cr88192/bgbtech_misc/blob/master/mini/btac1c_mini0.h)| MIT      |C/C++|**1**| MS-IMA_ADPCM variant
 |   |  [TinySoundFont](https://github.com/schellingb/TinySoundFont)         | MIT                  |C/C++|**1**| SoundFont2 loader & synthesizer
+|   |  [pocketmod](https://github.com/rombankzero/pocketmod)                | MIT                  |C/C++|**1**| ProTracker MOD file renderer
 
 # compression
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
This adds my own library, [pocketmod](https://github.com/rombankzero/pocketmod), to the list under the 'audio' section. Here are the quick facts:

- Renders ProTracker MOD files to PCM audio data
- One file (license included in the file)
- No external dependencies
- Written in C, but usable from C++ without modifications
- MIT license