### PR TITLE
Add yxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |  [inih](https://github.com/benhoyt/inih)                              | BSD                  |C/C++|  2  | .ini file parser
 |   |**[ini.h](https://github.com/mattiasgustavsson/libs)**                 | **public domain**    |C/C++|**1**| .ini file parser
 |   |  [cmp](https://github.com/camgunz/cmp)                                | MIT                  |C/C++|  2  | MessagePack parser and serializer
+|   |  [yxml](https://dev.yorhel.nl/yxml)                                   | MIT                  |C/C++|  2  | XML parser
 
 # profiling
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
From https://dev.yorhel.nl/yxml

XML may not be the best format when you want minimalism, but there *does* exist a 2-file lib to parse XML when you really have to. I've left the note after miscellaneous, as it still applies.