### PR TITLE
Added Vulkan Memory Allocator library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |**[seamoptimizer](https://github.com/ands/seamoptimizer)**             | **public domain**    |C/C++|**1**| modify lightmap data to hide seams
 |   |  [tinygizmo](https://github.com/ddiakopoulos/tinygizmo)               | **public domain**    | C++ |  2  | gizmo objects for interactively editing 3d transformations
 |   |**[Vertex Cache Optimizer](https://github.com/Sigkill79/sts)**         | **public domain**    |C/C++|**1**| vertex cache optimization of meshes
+|   |  [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator)|MIT|C/C++|**1**| memory allocator for Vulkan
 
 # hardware
 |   | library                                                               | license              | API |files| description


### PR DESCRIPTION
The library is "stb-style" single header. All is in file `vk_mem_alloc.h`, including header part (in C), implementation part (in C++), and documentation (in Doxygen-style comments). Rest of the files are just samples, tests, tools, etc. It works in 32-bit as well as 64-bit projects. It is multiplatform, used on a variety of desktop as well as mobile systems. License is MIT. 