### PR TITLE
Adding mini_al

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ as C/C++, as this is not an obstacle to most users.)
 |   |**[dr_flac](https://github.com/mackron/dr_libs)**                      | **public domain**    |C/C++|**1**| FLAC audio decoder
 |   |**[dr_wav](https://github.com/mackron/dr_libs)**                       | **public domain**    |C/C++|**1**| WAV audio loader
 |   |**[sts_mixer](https://github.com/kieselsteini/sts)**                   | **public domain**    |C/C++|**1**| simple stereo audio mixer
+|   |**[mini_al](https://github.com/dr-soft/mini_al)**                   | **public domain**    |C/C++|**1**| Audio playback and capture
 |   |  [tinysound](https://github.com/RandyGaul/tinyheaders)                | zlib                 |C/C++|**1**| direct sound audio mixer & WAV loader
 |   |  [btac1c](https://github.com/cr88192/bgbtech_misc/blob/master/mini/btac1c_mini0.h)| MIT      |C/C++|**1**| MS-IMA_ADPCM variant
 |   |  [TinySoundFont](https://github.com/schellingb/TinySoundFont)         | MIT                  |C/C++|**1**| SoundFont2 loader & synthesizer


### PR DESCRIPTION
This library only requires the inclusion of "mini_al.h". One file.