### PR TITLE
Hedley, TinyCThread, and TinyThread++

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [picobench](https://github.com/iboB/picobench)                       | MIT                  | C++ |**1**| microbenchmarking
 |  [ASAP](https://github.com/mobius3/asap)                              | MIT                  | C++ |**1**| library for parsing, printing, iterating and operating on dates.
 |**[process.h](https://github.com/sheredom/process.h)**                 | **public domain**    |C/C++|**1**| process control API
+|  [Hedley](https://nemequ.github.io/hedley/)                           | **public domain**    |C/C++|**1**| compiler portability, optimization, static analysis, etc.
 
 
 There are also these XML libraries, but if you're using XML, shame on you:

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ as C/C++, as this is not an obstacle to most users.)
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 |  [mm_sched.h](https://github.com/vurtun/mmx)                          | zlib                 |C/C++|**1**| cross-platform multithreaded task scheduler based on [enkiTS](https://github.com/dougbinks/enkiTS)
 |**[thread.h](https://github.com/mattiasgustavsson/libs)**              | **public domain**    |C/C++|**1**| cross-platform thread primitives
+|  [TinyCThread](https://tinycthread.github.io/)                        | zlib                 |C/C++|  2  | cross-platform implementation of the C11 Threads API
+|  [TinyThread++](https://tinythreadpp.bitsnbites.eu/)                  | zlib                 | C++ |  2  | cross-platform implementation of the C++11 Threads API
 
 # network
 | library                                                               | license              | API |files| description


### PR DESCRIPTION
[Hedley](https://nemequ.github.io/hedley/) is a single C/C++ header you can include in your project to enable compiler-specific features while retaining compatibility with all compilers. It contains dozens of macros to help make your code easier to use, harder to misuse, safer, faster, and more portable.

[TinyThread++](https://tinythreadpp.bitsnbites.eu/) is a portable implementation of the C++11 Threads API.

[TinyCThread](https://tinycthread.github.io/) is a portable implementation of the C11 Threads API.