### PR TITLE
Add ubench.h https://github.com/sheredom/ubench.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [stmr](https://github.com/wooorm/stmr.c)                             | MIT                  |  C  |  2  | extract English word stems
 |  [tinyformat](https://github.com/c42f/tinyformat)                     | Boost                | C++ |**1**| typesafe printf
 |  [tinytime](https://github.com/RandyGaul/tinyheaders)                 | zlib                 |C/C++|**1**| quick-and-dirty time elapsed time
+|**[ubench.h](https://github.com/sheredom/ubench.h)**                   | **public domain**    |C/C++|**1**| microbenchmarking 
 |  [visit_struct](https://github.com/cbeck88/visit_struct)              | Boost                | C++ |  2  | struct-field reflection
 
 


### PR DESCRIPTION
Added [ubench.h](https://github.com/sheredom/ubench.h) to miscellaneous.
I added it to miscellaneous as the only similar library I could find was [picobench](https://github.com/iboB/picobench) also in the miscellaneous section. Might be worth adding another category.                   
