### PR TITLE
Adding cpp-httplib to list of network libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [EWS](https://github.com/hellerf/EmbeddableWebServer)                | BSD                  |C/C++|**1**| HTTP server
 |  [happyhttp](https://github.com/Zintinio/HappyHTTP)                   | zlib                 | C++ |  2  | HTTP client requests
 |**[http](https://github.com/mattiasgustavsson/libs)**                  | **public domain**    |C/C++|**1**| HTTP get/post
+|  [cpp-httplib](https://github.com/yhirose/cpp-httplib)                | MIT                  | C++ |**1**| HTTP server & client library
 |  [libcluon](https://github.com/chrberger/libcluon)                    | MPL-2.0              | C++ |**1**| cross-platform socket wrapper and data marshalling with native implementations for [Protobuf](https://developers.google.com/protocol-buffers/), [LCM](http://lcm-proj.github.io/type_specification.html)/[ZCM](http://zerocm.github.io/zcm/), JSON, and [MsgPack](https://msgpack.org) serialization/deserialization
 |  [LUrlParser](https://github.com/corporateshark/LUrlParser)           | MIT                  | C++ |  2  | lightweight URL & URI parser RFC 1738, RFC 3986
 |  [mm_web.h](https://github.com/vurtun/mmx)                            | BSD                  |C/C++|**1**| lightweight webserver, fork of webby


### PR DESCRIPTION
Great library for simple HTTP client/server programming.  Useful as a quick drop-in for testing network code.

library: https://github.com/yhirose/cpp-httplib