### PR TITLE
Introduced CXXGraph Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [avl](https://github.com/etherealvisage/avl)                         | **public domain**    |C/C++|  2  | AVL tree
 |  [c-bool-value](https://github.com/lduck11007/c-bool-value)           | **WTFPLv2**          |C/C++|  1  | Simple and easy boolean values in standard c
 |  [chobo-shl](https://github.com/Chobolabs/chobo-shl)                  | MIT                  | C++ |**1**| several C++11 standard contaner like libraries and helpers
+|  [CXXGraph](https://github.com/ZigRazor/CXXGraph)                     | AGPL-3.0             | C++ |**1**| several C++17 standard utilities for Graph representation and Algorithms
 |**[DG_dynarr.h](https://github.com/DanielGibson/Snippets/)**           | **public domain**    |C/C++|**1**| typesafe dynamic arrays (like std::vector) for plain C
 |  [DynaVar](https://github.com/ArjArav98/DynaVar)                      | GPL-3.0              | C++ |  1  | Object which can store any type of primitive data type
 |  [klib](http://attractivechaos.github.io/klib/)                       | MIT                  |C/C++|  2  | many 2-file libs: hash, sort, b-tree, etc


### PR DESCRIPTION
Introduced CXXGraph header-only Library for represent and execute algorithms on Graph

Include the link to the library in your description, as well as in the PR itself.
