### PR TITLE
Add json-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ as C/C++, as this is not an obstacle to most users.)
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
 |  [ajson](https://github.com/lordoffox/ajson)                          | Boost                | C++ |**1**| JSON serialize & deserialize w/ STL support
 |  [cJSON](https://sourceforge.net/projects/cjson/)                     | MIT                  |C/C++|**1**| JSON parser
+|  [json-build](https://github.com/lcsmuller/json-build)                | MIT                  |C/C++|**1**| JSON serializer
 |  [json.h](https://github.com/sheredom/json.h)                         | **public domain**    |C/C++|  2  | JSON parser
 |  [json.hpp](https://github.com/nlohmann/json)                         | MIT                  | C++ |**1**| JSON parse, serialize, deserialize
 |  [jzon.h](https://github.com/Zguy/Jzon)                               | MIT                  | C++ |  2  | JSON parser


### PR DESCRIPTION
[json-build](https://github.com/lcsmuller/json-build) is a tiny zero-allocation C89 JSON builder, targetting embedded systems.