### PR TITLE
Add walter.h unit test lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [trompeloeil](https://github.com/rollbear/trompeloeil)               | Boost                | C++ |**1**| unit testing
 |  [utest](https://github.com/evolutional/utest)                        | MIT                  |C/C++|**1**| unit testing
 |**[utest.h](https://github.com/sheredom/utest.h)**                     | **public domain**    |C/C++|**1**| unit testing
+|**[walter](https://github.com/ir33k/walter)**                          | **public domain**    |  C  |**1**| unit testing
 
 # user interface
 | library                                                               | license              | API |files| description


### PR DESCRIPTION
Hi, I was using this single header C unit test lib for my own projects and recently decided to share it with others.

https://github.com/ir33k/walter

Comparing to other similar libs this focus on minimizing tests setup AKA boilerplate and printing direct paths with line numbers to failed or pending tests.

Happy coding