### PR TITLE
jo_mpeg converted to C

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ as C/C++, as this is not an obstacle to most users.)
 # video
 | library                                                               | license              | API |files| description
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|  [jo_mpeg](http://www.jonolick.com/home/mpeg-video-writer)            | **public domain**    | C++ |**1**| MPEG file writer
+|  [jo_mpeg](http://www.jonolick.com/home/mpeg-video-writer) / [(converted to C)](https://github.com/FrostKiwi/treasurechest#jo_mpeg-converted-to-c)            | **public domain**    | C/C++ |**1**| MPEG file writer
 
 # videogames
 | library                                                               | license              | API |files| description

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ as C/C++, as this is not an obstacle to most users.)
 # video
 | library                                                               | license              | API |files| description
 | --------------------------------------------------------------------- |:--------------------:|:---:|:---:| -----------
-|  [jo_mpeg](http://www.jonolick.com/home/mpeg-video-writer) / [(converted to C)](https://github.com/FrostKiwi/treasurechest#jo_mpeg-converted-to-c)            | **public domain**    | C/C++ |**1**| MPEG file writer
+|  [jo_mpeg](http://www.jonolick.com/home/mpeg-video-writer) / [(converted to C)](https://blog.frost.kiwi/jo-mpeg-in-c)            | **public domain**    | C/C++ |**1**| MPEG file writer
 
 # videogames
 | library                                                               | license              | API |files| description


### PR DESCRIPTION
I'm a big fan of jo_mpeg and it's ability to create MPEG1 video files in such a small source file.

The library is listed as C++ only, however only a small change needs to be done to make it compile in both C and C++. I performed this change and linked to it in the README.

I tried to suggest this to the author as a comment on the original blog but it wasn't picked up. There is also no git repo for that single file library, so I thought I just link it here.