### PR TITLE
Expanded API column title

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Also you might be interested in other related, but different lists:
 
 ### Library listing
 
-| tag  | library                                                              | license          | API |files| description
+| tag  | library                                                              | license          | &nbsp;&nbsp;&nbsp;API&nbsp;&nbsp;&nbsp; |files| description
 | ---- | -------------------------------------------------------------------- |:----------------:|:---:|:---:| -----------
 2d     | [blendish](https://hg.sr.ht/~duangle/oui-blendish)                   | MIT              |C/C++|  1  | blender-style widget rendering using NanoVG
 2d     | [C-Turtle](https://github.com/walkerje/C-Turtle)                     | MIT              | C++ |**1**| Port of Python's Turtle to C++


### PR DESCRIPTION
Used non-breaking space characters to pad out the API column so that the "C/C++" string won't end up breaking across 2 to 3 lines.

A total of 6 `nbsp`s had to be used, and I had to put 3 on either side to have proper centring of the title (putting them all in the end made the title shift to left).

Fixes https://github.com/r-lyeh/single_file_libs/issues/276
