### PR TITLE
Add Convenient Containers and Verstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Single-header C files with clause-less licenses are highlighted.
 *ds*      |[AArray](https://tse.gratis/aArray/)                                                                                **(1   C, PD)**          |**Arrays/strings: generic, safe**
 *ds*      |[Avl](https://github.com/etherealvisage/avl)                                                                          (2   C, PD)            |AVL tree
 *ds*      |[Cds_algo](https://github.com/cdwfs/algo)                                                                           **(1   C, PD)**          |**Collection of data structures (queue, stack, graph, heap...)**
+*ds*      |[Convenient Containers](https://github.com/JacksonAllan/CC)                                                           (1   C, MIT)           |Typesafe data structures (vector, list, map, set, string, etc.) with a fully generic API and no boilerplate
 *ds*      |[DG_dynarr.h](https://github.com/DanielGibson/Snippets/)                                                            **(1   C, PD)**          |**Typesafe dynamic arrays (like std::vector) for plain C**
 *ds*      |[Dynarr](https://github.com/BareRose/dynarr)                                                                        **(1   C, PD)**          |**Dynamic array container**
 *ds*      |[DynaVar](https://github.com/ArjArav98/DynaVar)                                                                       (1 C++, GPL3)          |Object which can store any type of primitive data type
@@ -199,6 +200,7 @@ Single-header C files with clause-less licenses are highlighted.
 *ds*      |[Simclist](https://mij.oltrelinux.com/devel/simclist)                                                                 (2   C, BSD)           |Linked-list
 *ds*      |[Stb_ds](https://github.com/nothings/stb/blob/master/stb_ds.h)                                                      **(1   C, PD)**          |**Typesafe dynamic array and hash tables for   C, will compile in C++**
 *ds*      |[Uthash](https://github.com/troydhanson/uthash)                                                                       (2   C, BSD)           |Several 1-header, 1-license-file libs: generic hash, list, etc
+*ds*      |[Verstable](https://github.com/JacksonAllan/Verstable)                                                                (1   C, MIT)           |High performance and typesafe generic hash table
 *engine*  |[Kit](https://github.com/rxi/kit)                                                                                   **(1   C, PD)**          |**Tiny library for making small games with big pixels**
 *engine*  |[OlcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine)                                              (1 C++, BSD3)          |Game engine
 *engine*  |[Punity](https://github.com/martincohen/Punity)                                                                       (1   C, MIT)           |A tiny game engine in C


### PR DESCRIPTION
Hello! This pull request adds two data structure libraries.

The first is [Convenient Containers](https://github.com/JacksonAllan/CC). The library's main selling points are summarized in the [_Rationale_](https://github.com/JacksonAllan/CC#rationale) section of its README. In short, by harnessing some rather novel techniques, the library is able to provide a range of fully typesafe data structures with a generic API agnostic to container and data types, without requiring the user to make any boilerplate container type or struct pre-declarations. CC is the only data structure library that offers these features, to the best of my knowledge.

The second is [Verstable](https://github.com/JacksonAllan/Verstable). It is a dedicated hash table (i.e. maps and sets) library that takes a more traditional approach to generics by requiring users to pre-declare hash table types (as in [khash](https://attractivechaos.github.io/klib/#Khash%3A%20generic%20hash%20table), [STC](https://github.com/stclib/STC), etc.), although it still manages to provide a generic API compatible with all the hash table types that the user declares. Verstable's top priority is performance, and it has been [thoroughly benchmarked](https://jacksonallan.github.io/c_cpp_hash_tables_benchmark/) against other C and C++ hash table libraries (including the current top performers).

Convenient Containers and Verstable are related in that the former's hash table implementation is based on the latter.

Both libraries consist of a single header and are usable in C and C++. However, in each case, associated materials - such as test suites and additional documentation - are included in the same repository. These additional files are not needed to use the libraries.

Both include the license (MIT) in the header itself. The license is duplicated in a separate file only for the purpose of allowing GitHub to infer and display that the libraries are MIT-licensed.

The libraries are intended to - and should - work fine on both 64-bit and 32-bit platforms. However, they are only routinely tested on 64-bit platforms because of the difficulty of accessing a 32-bit platform.

The libraries are usable on multiple platforms. Before every release, they are tested (in both C and C++) on Windows using MSVC and MinGW-64 (GCC) and on Linux using GCC and Clang.

Thanks for considering them :)