### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Single-header C files with clause-less licenses are highlighted.
 *misc*    |[Stmr](https://github.com/wooorm/stmr.c)                                                                              (2   C, MIT)           |Extract English word stems
 *misc*    |[X.h](https://github.com/Neur1n/x.h)                                                                                  (1   C, MULAN2)        |Cross-platform C/C++ utilities
 *nav*     |[M_path_finding.h](https://github.com/anael-seghezzi/Maratis-Tiny-C-library/blob/master/include/m_path_finding.h)     (1   C, ZLIB)          |Floodfill-based path finding
-*nav*     |[Micropather](https://www.grinninglizard.com/MicroPather/)                                                            (2 C++, ZLIB)          |Pathfinding with A\*
+*nav*     |[Micropather](https://github.com/leethomason/MicroPather)                                                             (2 C++, ZLIB)          |Pathfinding with A\*
 *net*     |[Civetweb](https://github.com/civetweb/civetweb)                                                                      (2   C, MIT)           |HTTP server, fork of Mongoose
 *net*     |[Cpp-httplib](https://github.com/yhirose/cpp-httplib)                                                                 (1   C, MIT)           |Cross-platform HTTP server/client
 *net*     |[Enet](https://github.com/zpl-c/enet)                                                                                 (1   C, MIT)           |Reliable UDP networking library


### PR DESCRIPTION
The original link to `Micropather` 404s --apparently the guy forgot to pay his VPS bills.
However, he seems to have a Github mirror, luckily.