### PR TITLE
Add clownresampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Single-header C files with clause-less licenses are highlighted.
 *audio*   |[Aw_ima.h](https://github.com/afterwise/aw-ima/blob/master/aw-ima.h)                                                  (1   C, MIT)           |IMA-ADPCM audio decoder
 *audio*   |[Btac1c](https://github.com/cr88192/bgbtech_misc/blob/master/mini/btac1c_mini0.h)                                     (1   C, MIT)           |MS-IMA_ADPCM variant
 *audio*   |[Chibi-xmplay](https://github.com/reduz/chibi-xmplay)                                                                 (2   C, BSD3)          |XM module playback library
+*audio*   |[clownresampler](https://github.com/Clownacy/clownresampler)                                                        **(1   C, BSD0)**        |**Audio resampling**
 *audio*   |[Miniaudio](https://github.com/mackron/miniaudio)                                                                     (2   C, PD)            |Audio playback and capture library
 *audio*   |[Miniflac](https://github.com/jprjr/miniflac)                                                                       **(1   C, BSD0)**        |**FLAC decoder with a push-style API**
 *audio*   |[Minimp3](https://github.com/lieff/minimp3)                                                                         **(1   C, CC0)**         |**Minimalistic MP3 decoder with sse/neon support**


### PR DESCRIPTION
- [x] Library is in C89, uses `#ifdef __cplusplus / extern "C"`.
- [x] Library includes the licensing terms in the header file, is "licensed under the terms of the Zero-Clause BSD licence."
- [x] Tests produce identical output between 32- and 64-bit.
- [x] Library has no platform dependencies besides the C standard library.
- [x] Library is one header file (plus an optional source file that just includes the header file).