### PR TITLE
Added RolandMarchand/vector.h (1, C, BSD0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Single-header C files with clause-less licenses are highlighted.
 *ds*      |[Simclist](https://mij.oltrelinux.com/devel/simclist)                                                                 (2   C, BSD)           |Linked-list
 *ds*      |[Stb_ds](https://github.com/nothings/stb/blob/master/stb_ds.h)                                                      **(1   C, PD)**          |**Typesafe dynamic array and hash tables for   C, will compile in C++**
 *ds*      |[Uthash](https://github.com/troydhanson/uthash)                                                                       (2   C, BSD)           |Several 1-header, 1-license-file libs: generic hash, list, etc
+*ds*      |[Vector](https://github.com/RolandMarchand/vector.h)                                                                  (1   C, BSD0)          |Type-safe dynamic arrays
 *ds*      |[Verstable](https://github.com/JacksonAllan/Verstable)                                                                (1   C, MIT)           |High performance and typesafe generic hash table
 *engine*  |[Kit](https://github.com/rxi/kit)                                                                                   **(1   C, PD)**          |**Tiny library for making small games with big pixels**
 *engine*  |[OlcPixelGameEngine](https://github.com/OneLoneCoder/olcPixelGameEngine)                                              (1 C++, BSD3)          |Game engine


### PR DESCRIPTION
Added [RolandMarchand/vector.h](https://github.com/RolandMarchand/vector.h), type-safe dynamic arrays for C.

- C89 compliant
- Single header file
- Compiles on (tested so far):
  - x86
  - x86_64
  - ARM64
- Compiles with (tested so far):
  - GCC (-Wall -Wextra -pedantic -std=c89)
  - Clang (-Wall -Wextra -pedantic -std=c89)
  - MSVC (/W4)
  - ICX
- Comes with an extensive test suite that works with all of the above
- Licensed under the BSD0 license