### PR TITLE
Add tiny-webp

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ Single-header C files with clause-less licenses are highlighted.
 *image*   |PNG [TinyPngOutput](https://www.nayuki.io/page/tiny-png-output)                                                       (2   C, LGPLv3)        |PNG writer 
 *image*   |PNM [PNM](https://github.com/dmilos/PNM)                                                                              (1 C++, APACHE2)       |PBM, PGM and PPM reader and writer 
 *image*   |SVG [NanoSVG](https://github.com/memononen/nanosvg)                                                                   (1   C, ZLIB)          |1-file SVG parser; 1-file SVG rasterizer
-*image*   |WEBP [Jebp](https://github.com/matanui159/jebp)                                                                     **(1   C, 0MIT)**        |**Single header WebP decoder**
+*image*   |WEBP [Jebp](https://github.com/matanui159/jebp)                                                                     **(1   C, 0MIT)**        |**Single header WebP decoder (only supports lossless images)**
+*image*   |WEBP [tiny-webp](https://github.com/justus2510/tiny-webp)                                                             (1   C, BSD3)          |Single header WebP decoder
 *ini*     |[Inih](https://github.com/benhoyt/inih)                                                                               (2   C, BSD)           |.ini file parser
 *input*   |[EasyTab](https://github.com/ApoorvaJ/EasyTab)                                                                      **(1   C, PD)**          |**Multi-platform tablet input**
 *json*    |[Ajson](https://github.com/lordoffox/ajson)                                                                           (1 C++, BOOST)         |JSON serialize & deserialize w/ STL support


### PR DESCRIPTION
I wrote this library a couple months ago because JebP (which as far as I can tell was the only single-header WebP library) only supports lossless images (and not all lossless images either).

This library should support all of WebP, with the exception of animations.

Unfortunately, as far as I can tell, it's not possible to use a more permissive license than BSD3. (See [this](https://github.com/justus2510/tiny-webp?tab=readme-ov-file#license) comment.)