### PR TITLE
Add csonpath JSON library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Single-header C files with clause-less licenses are highlighted.
 *json*    |[Ajson](https://github.com/lordoffox/ajson)                                                                           (1 C++, BOOST)         |JSON serialize & deserialize w/ STL support
 *json*    |[CJSON](https://github.com/DaveGamble/cJSON)                                                                          (1   C, MIT)           |JSON parser
 *json*    |[CJSON](https://sourceforge.net/projects/cjson/)                                                                      (1   C, MIT)           |JSON parser
+*json*    |[csonpath](https://github.com/outscale/csonpath)                                                                      (1   C, BSD3)          |JsonPath implementation
 *json*    |[Jsmn](https://github.com/zserge/jsmn)                                                                                (1   C, MIT)           |Minimalistic JSON parser
 *json*    |[Json-build](https://github.com/lcsmuller/json-build)                                                                 (1   C, MIT)           |JSON serializer
 *json*    |[Json.h](https://github.com/sheredom/json.h)                                                                        **(1   C, PD)**          |**JSON parser**


### PR DESCRIPTION
Hello, 
I've made a JSONPath library that can be use a dual-file library. 
It's in GNU C 11, and compile with gcc, clang and tinycc.

If used like so, the JSON is abstract, and the user need to define a few macros to use it. (and then include csonpath.h) 

Otherwise, the lib contains a json-c, yyjson and a python module implementations,
but in this case it would be a 3 files libs.

The lib was made so it can be use either directly from one of the implementations, or as a headers-only lib.

Note that, I've added it in the JSON section, but maybe a JSONPath section could be added.

Remember the rules:
- Libraries must be usable from C or C++, ideally both (C/C++).
- Libraries must include the licensing terms in the header and source files: PD/MIT0/0BSD/CC0 are preferred. Multi-licensed is even better.
- Libraries should compile and work on both 32-bit and 64-bit platforms.
- Libraries should be usable from more than one platform (ideally, all major desktops and/or all major mobile).
- Libraries should use at most two files (one header, one source): more than two files are mostly forbidden but still debatable.

**Please consider postponing the PR if the submission does not guarantee most of the conditions above.**

You can also chat/discuss about C/C++ and Game development in our discord channel: https://discord.gg/2fZVEym
The server is meant to be a pleasant space to chat about C, C++, Libs authoring and Game development specifically.
