### PR TITLE
Add FlexiC

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Single-header C files with clause-less licenses are highlighted.
 *pack*    |[Stb_dxt](https://github.com/nothings/stb/blob/master/stb_dxt.h)                                                    **(1   C, PD)**          |**Real-time DXT compressor**
 *parse*   |[Cmp](https://github.com/camgunz/cmp)                                                                                 (2   C, MIT)           |MessagePack parser and serializer
 *parse*   |[Cpp-peglib](https://github.com/yhirose/cpp-peglib)                                                                   (1   C, MIT)           |PEG (Parsing Expression Grammars) library
+*parse*   |[FlexiC](https://github.com/leximayfield/flexic)                                                                      (2   C, ZLIB)          |Google FlexBuffer parser and writer
 *parse*   |[Furi](https://github.com/iboB/furi)                                                                                  (1   C, MIT)           |URL & URI parsing
 *parse*   |[Html-parse.c](https://git.savannah.gnu.org/cgit/wget.git/tree/src/html-parse.c)                                      (2   C, GPL)           |HTML parser (wget)
 *parse*   |[SLRE](https://github.com/aquefir/slre)                                                                               (1   C, GPL2)          |Regular expression matcher


### PR DESCRIPTION
A Google FlexBuffer parser and writer

✅ Libraries must be usable from C or C++, ideally both (C/C++).  **C++ compilation is tested in CI.**
✅ Libraries must include the licensing terms in the header and source files: PD/MIT0/0BSD/CC0 are preferred. Multi-licensed is even better.  **Zlib license, which only requires in-source attribution.**
✅ Libraries should compile and work on both 32-bit and 64-bit platforms. **32-bit is tested in CI.**
✅ Libraries should be usable from more than one platform (ideally, all major desktops and/or all major mobile). **Tested on Windows and Linux.  Has been compiled for STM32, though this has not been added to CI yet.**
✅ Libraries should use at most two files (one header, one source): more than two files are mostly forbidden but still debatable. **One header, one source file.**

EDIT: I went ahead and added macOS on ARM silicon to CI - no troubles there.