### PR TITLE
Add, VeloxFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Single-header C files with clause-less licenses are highlighted.
 *file*    |[Miniphysfs](https://github.com/edubart/miniphysfs)                                                                   (1   C, ZLIB)          |Single-file port of PhysFS, a fs/zip abstraction
 *file*    |[Tfile](https://github.com/rec/tfile)                                                                                 (1 C++, MIT)           |FILE* wrapper does read-write-append-seek-close (Win/Mac/Unix)
 *file*    |[TinyDir](https://github.com/cxong/tinydir)                                                                           (1   C, BSD)           |Cross-platform directory reading (Win/POSIX/MinGW)
+*file*    |[VeloxFS](https://github.com/Partakithware/VeloxFS)                                                                 **(1   C, PD)**          |Single-header C99 filesystem for embedded, game assets, or persistent binary storage
 *file*    |[Whereami](https://github.com/gpakosz/whereami)                                                                       (2   C, WTFPL2)        |Get path/filename of executable or module
 *font*    |[Blit-fonts](https://github.com/azmr/blit-fonts)                                                                      (1   C, ISC)           |Bitmap font blitters
 *font*    |[Ssfn.h](https://gitlab.com/bztsrc/scalable-font)                                                                     (1   C, MIT)           |Scalable/bitmap/pixmap font renderer


### PR DESCRIPTION
I am a hobbyist, so I apologize if this isn't 100% correct but it should be, feel free to check it out and let me know if that's not the case!

[VeloxFS](https://github.com/Partakithware/VeloxFS)
Title: Add VeloxFS to file category

Body:
I'd like to submit VeloxFS to the list under the *file* tag.

VeloxFS is a robust, general-purpose C99 single-header filesystem library. It uses a FAT-linked allocation strategy and includes a circular write-ahead journal to ensure data integrity and crash-safety. It is designed to provide a portable, easy-to-integrate storage layer within any application needing to manage files inside a flat binary container.

Compliance Check: Should be golden!

    Single File: Entirely contained in veloxfs.h.

    C/C++ Compatible: Tested with both; includes extern "C" guards.

    License: Dual-licensed (MIT and Unlicense) included in the header.

    Multi-platform: Uses standard fixed-width types and cross-platform structure packing macros.

    Architecture: 32-bit and 64-bit compatible.