### PR TITLE
Add easy_memory to the *mem* section

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Single-header C files with clause-less licenses are highlighted.
 *math*    |[Voxelizer](https://github.com/karimnaaji/voxelizer)                                                                  (1   C, MIT)           |Convert triangle mesh to voxel triangle mesh
 *math*    |[Xatlas](https://github.com/jpcy/xatlas)                                                                              (2 C++, MIT)           |Mesh parameterization
 *mem*     |[Buddy_alloc](https://github.com/spaskalev/buddy_alloc)                                                             **(1   C, BSD0)**        |**Buddy memory allocator**
+*mem*     |[easy_memory](https://github.com/EasyMem/easy_memory)                                                                 (1   C, MIT)           |Platform-agnostic memory management system with LLRB trees and modular sub-allocators
 *mem*     |[Stb_leakcheck](https://github.com/nothings/stb/blob/master/stb_leakcheck.h)                                        **(1   C, PD)**          |**Quick-and-dirty malloc/free leak-checking**
 *mem*     |[Wb_alloc](https://github.com/WilliamBundy/wb_alloc)                                                                **(1   C, PD)**          |**Custom allocators in a single-header**
 *mesh*    |[Cgltf](https://github.com/jkuhlmann/cgltf)                                                                           (1   C, MIT)           |GlTF 2.0 file loader


### PR DESCRIPTION
Hello! 

I would like to add `easy_memory` to the `*mem*` category (placed alphabetically between `Buddy_alloc` and `Stb_leakcheck`).

`easy_memory` is a strictly typed, platform-agnostic, and safe memory management system for C/C++ featuring arbitrary alignment, scoped lifecycles, and modular sub-allocators.

Here is how it meets the repository rules:
- **Language:** Written in pure C99/C11, fully compatible with C++ (wrapped in `extern "C"`).
- **Licensing:** Licensed under MIT, with the full license text embedded directly at the top of the header file.
- **32-bit & 64-bit:** Fully compatible and tested on both 32-bit and 64-bit architectures.
- **Multi-platform:** Verified on Linux (GCC, Clang), macOS, Windows (MSVC, MinGW), ARM32/64, and s390x (Big Endian). It is embedded/kernel-space ready with `#define EM_NO_MALLOC`.
- **Files:** A single, header-only library (`easy_memory.h`).

The library is battle-tested with continuous fuzzing (libFuzzer), sanitizers (ASan, UBSan, LSan), and has ~100% test coverage.

Thank you for maintaining this awesome list!