### PR TITLE
add math expression evaluation libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ Single-header C files with clause-less licenses are highlighted.
 *math*    |[Vmath](https://github.com/monolifed/vmath)                                                                         **(1   C, PD)**          |**Vector/matrix library**
 *math*    |[Voxelizer](https://github.com/karimnaaji/voxelizer)                                                                  (1   C, MIT)           |Convert triangle mesh to voxel triangle mesh
 *math*    |[Xatlas](https://github.com/jpcy/xatlas)                                                                              (2 C++, MIT)           |Mesh parameterization
+*math-str*|[Evalmath](https://github.com/ribbon-otter/evalmath)                                                                  (2 C++, 0MIT)          |C++23 simple math string evaluation with specific error messages
+*math-str*|[TinyExpr](https://github.com/codeplea/tinyexpr)                                                                      (2   C, ZLIB)          |C99 math string evaluation and compilation with rebindable variables
+*math-str*|[Miscsrc's eval.h & eval.cpp](https://github.com/wernsey/miscsrc)                                                     (2   C, UNLICENSE)     |C math string evaluation
 *mem*     |[Buddy_alloc](https://github.com/spaskalev/buddy_alloc)                                                             **(1   C, BSD0)**        |**Buddy memory allocator**
 *mem*     |[easy_memory](https://github.com/EasyMem/easy_memory)                                                                 (1   C, MIT)           |Platform-agnostic memory management system with LLRB trees and modular sub-allocators
 *mem*     |[Stb_leakcheck](https://github.com/nothings/stb/blob/master/stb_leakcheck.h)                                        **(1   C, PD)**          |**Quick-and-dirty malloc/free leak-checking**


### PR DESCRIPTION
This adds a new section of "math-str" libraries (i.e. math expression evaluation libraries but that is too long). 

Disclosure: evalmath is my library. 